### PR TITLE
refs #455 fixed a bug where collections with no columns (but based on…

### DIFF
--- a/RELEASE-NOTES
+++ b/RELEASE-NOTES
@@ -41,6 +41,8 @@ version 3.2
   would result in an ORA-01406 error
 * fixed a bug where number values were being returned with decimal points
   truncated in locales where the decimal position is not marked with a dot
+* fixed a bug where collections with no columns (but based on a table for
+  example) could not be used
 
 
 ***********

--- a/docs/mainpage.doxygen.tmpl
+++ b/docs/mainpage.doxygen.tmpl
@@ -493,6 +493,7 @@ kpcest_err_handler: Max errors exceeded..Closing connection
     - fixed a bug where duplicated columns would result in corrupt lists when selected in column mode
     - fixed a bug where very large numbers were being retrieved incorrectly and would result in an ORA-01406 error
     - fixed a bug where number values were being returned with decimal points truncated in locales where the decimal position is not marked with a dot
+    - fixed a bug where collections with no columns (but based on a table for example) could not be used (<a href="https://github.com/qorelanguage/qore/issues/455">bug 455</a>)
 
     @subsection oracle31 oracle Driver Version 3.1
 

--- a/src/oracleobject.cpp
+++ b/src/oracleobject.cpp
@@ -47,7 +47,7 @@ void ocilib_err_handler(OCI_Error *err, ExceptionSink* xsink) {
              "  icode : %d\n"
              "  msg   : %s\n",
              //"  sql   : %s\n",
-             OCI_ErrorGetOCICode(err), 
+             OCI_ErrorGetOCICode(err),
              OCI_ErrorGetInternalCode2(err),
              OCI_ErrorGetString(err)
              //OCI_GetSql(OCI_ErrorGetStatement(err))
@@ -197,7 +197,7 @@ OCI_Object* objBindQore(QoreOracleConnection * d, const QoreHashNode * h, Except
 
     const QoreHashNode* th = reinterpret_cast<const QoreHashNode*>(h->getKeyValue("^values^"));
     const char* tname = reinterpret_cast<const QoreStringNode*>(h->getKeyValue("^oratype^"))->getBuffer();
-    
+
     OCI_TypeInfo * info = OCI_TypeInfoGet2(&d->ocilib, d->ocilib_cn, tname, OCI_TIF_TYPE, xsink);
     if (!info) {
        if (!*xsink)
@@ -224,7 +224,7 @@ OCI_Object* objBindQore(QoreOracleConnection * d, const QoreHashNode * h, Except
           xsink->raiseException("BIND-NTY-ERROR", "failed to retrieve column information for column %d for object type '%s'", 1, tname);
           return 0;
        }
-        
+
        const char* cname = OCI_ColumnGetName2(&d->ocilib, col, xsink);
        if (*xsink)
           return 0;
@@ -255,7 +255,7 @@ OCI_Object* objBindQore(QoreOracleConnection * d, const QoreHashNode * h, Except
            }
 	   continue;
         }
-        
+
         switch (col->ocode) {
             case SQLT_LNG: // long
             case SQLT_AFC:
@@ -319,7 +319,7 @@ OCI_Object* objBindQore(QoreOracleConnection * d, const QoreHashNode * h, Except
                          if (!*xsink)
                             xsink->raiseException("BIND-NTY-ERROR", "NUMBER: unable to assign a string value to object attribute %s.%s", tname, cname);
                          return 0;
-                      }                      
+                      }
                       break;
                    }
 #endif
@@ -357,7 +357,7 @@ OCI_Object* objBindQore(QoreOracleConnection * d, const QoreHashNode * h, Except
 
             case SQLT_DAT:
             case SQLT_ODT:
-            case SQLT_DATE: 
+            case SQLT_DATE:
 #if OCI_VERSION_COMPILE >= OCI_9_0
             case SQLT_TIMESTAMP:
             case SQLT_TIMESTAMP_TZ:
@@ -368,7 +368,7 @@ OCI_Object* objBindQore(QoreOracleConnection * d, const QoreHashNode * h, Except
             {
                 // date
                 DateTimeValueHelper dn(val);
-                
+
                 if (col->type == OCI_CDT_TIMESTAMP) {
                    //printd(0, "bind %p: %s.%s: %d: binding timestamp\n", &obj, tname, cname, i);
                    OCI_Timestamp* dt = OCI_TimestampCreate2(&d->ocilib, d->ocilib_cn, col->subtype, xsink);
@@ -383,7 +383,7 @@ OCI_Object* objBindQore(QoreOracleConnection * d, const QoreHashNode * h, Except
                                                 dn->getHour(), dn->getMinute(), dn->getSecond(),
                                                 (dn->getMicrosecond() * 1000),
                                                 0, xsink)) {
-                      if (!*xsink) 
+                      if (!*xsink)
                          xsink->raiseException("BIND-NTY-ERROR", "failed to create timestamp from date/time value for object attribute %s.%s", tname, cname);
                       return 0;
                    }
@@ -407,7 +407,7 @@ OCI_Object* objBindQore(QoreOracleConnection * d, const QoreHashNode * h, Except
                    if (!OCI_DateSetDateTime(&d->ocilib, dt,
                                             dn->getYear(), dn->getMonth(), dn->getDay(),
                                             dn->getHour(), dn->getMinute(), dn->getSecond())) {
-                      if (!*xsink) 
+                      if (!*xsink)
                          xsink->raiseException("BIND-NTY-ERROR", "failed to create date/time value for object attribute %s.%s", tname, cname);
                       return 0;
                    }
@@ -431,12 +431,12 @@ OCI_Object* objBindQore(QoreOracleConnection * d, const QoreHashNode * h, Except
                        }
                        ON_BLOCK_EXIT(OCI_IntervalFree2, &d->ocilib, dt);
                        if (!OCI_IntervalSetYearMonth2(&d->ocilib, dt, dn->getYear(), dn->getMonth(), xsink)) {
-                          if (!*xsink) 
+                          if (!*xsink)
                              xsink->raiseException("BIND-NTY-ERROR", "failed to set interval year/month value for object attribute %s.%s", tname, cname);
                           return 0;
                        }
                        if (!OCI_ObjectSetInterval2(&d->ocilib, *obj, cname, dt, xsink)) {
-                          if (!*xsink) 
+                          if (!*xsink)
                              xsink->raiseException("BIND-NTY-ERROR", "failed to set interval value for object attribute %s.%s", tname, cname);
                           return 0;
                        }
@@ -457,12 +457,12 @@ OCI_Object* objBindQore(QoreOracleConnection * d, const QoreHashNode * h, Except
                                                    dn->getDay(),
                                                    dn->getHour(), dn->getMinute(), dn->getSecond(),
                                                    (dn->getMicrosecond() * 1000), xsink)) {
-                       if (!*xsink) 
+                       if (!*xsink)
                           xsink->raiseException("BIND-NTY-ERROR", "failed to set interval day/second value for object attribute %s.%s", tname, cname);
                        return 0;
                     }
                     if (!OCI_ObjectSetInterval2(&d->ocilib, *obj, cname, dt, xsink)) {
-                       if (!*xsink) 
+                       if (!*xsink)
                           xsink->raiseException("BIND-NTY-ERROR", "failed to set interval value for object attribute %s.%s", tname, cname);
                        return 0;
                     }
@@ -565,7 +565,7 @@ OCI_Object* objBindQore(QoreOracleConnection * d, const QoreHashNode * h, Except
             case SQLT_NTY: {
                 const QoreHashNode* n = dynamic_cast<const QoreHashNode*>(val);
                 const char *t = ntyHashType(n);
-                if (t && !strcmp(t, ORACLE_OBJECT)) {                    
+                if (t && !strcmp(t, ORACLE_OBJECT)) {
                    ObjectHolder o(&d->ocilib, objBindQore(d, n, xsink), xsink);
                    if (!o) {
                       assert(*xsink);
@@ -641,10 +641,10 @@ AbstractQoreNode* objToQore(QoreOracleConnection* conn, OCI_Object* obj, Excepti
       xsink->raiseException("FETCH-NTY-ERROR", "unable to retrieve attribute info for object: %s.%s", get_typinf_schema(obj), get_typinf_name(obj));
       return 0;
    }
-   for (int i = 1; i <= n; ++i) {        
+   for (int i = 1; i <= n; ++i) {
       OCI_Column* col = OCI_TypeInfoGetColumn2(&conn->ocilib, obj->typinf, i, xsink);
       if (!col) {
-         if (!*xsink) 
+         if (!*xsink)
             xsink->raiseException("FETCH-NTY-ERROR", "Object of type %s.%s failed to retrieve column information for column %d", get_typinf_schema(obj), get_typinf_name(obj), i);
          return 0;
       }
@@ -655,7 +655,7 @@ AbstractQoreNode* objToQore(QoreOracleConnection* conn, OCI_Object* obj, Excepti
             xsink->raiseException("FETCH-NTY-ERROR", "Object of type %s.%s failed to retrieve column name for column %d (%s)", get_typinf_schema(obj), get_typinf_name(obj), i, col->name);
          return 0;
       }
-        
+
       {
          bool b = OCI_ObjectIsNull2(&conn->ocilib, obj, cname, xsink);
          if (*xsink)
@@ -699,7 +699,7 @@ AbstractQoreNode* objToQore(QoreOracleConnection* conn, OCI_Object* obj, Excepti
 
             char buf[ORA_NUM_BUFSIZE + 1];
             ub4 bs = ORA_NUM_BUFSIZE;
-            if (conn->checkerr(OCINumberToText(conn->errhp, num, (const OraText*)ORA_NUM_FORMAT, ORA_NUM_FORMAT_SIZE, 0, 0, &bs, (OraText*)buf), 
+            if (conn->checkerr(OCINumberToText(conn->errhp, num, (const OraText*)ORA_NUM_FORMAT, ORA_NUM_FORMAT_SIZE, 0, 0, &bs, (OraText*)buf),
                                "objToQore() converting NUMERIC value to text", xsink))
                return 0;
             buf[bs] = 0;
@@ -751,7 +751,7 @@ AbstractQoreNode* objToQore(QoreOracleConnection* conn, OCI_Object* obj, Excepti
 
 	 case SQLT_DAT:
 	 case SQLT_ODT:
-	 case SQLT_DATE: 
+	 case SQLT_DATE:
 #if OCI_VERSION_COMPILE >= OCI_9_0
 	 case SQLT_TIMESTAMP:
 	 case SQLT_TIMESTAMP_TZ:
@@ -847,7 +847,7 @@ AbstractQoreNode* objToQore(QoreOracleConnection* conn, OCI_Object* obj, Excepti
             ON_BLOCK_EXIT(OCI_LobFree, &conn->ocilib, l, xsink);
 
 	    // The returned value is in bytes for BLOBS and characters for CLOBS/NCLOBs
-            
+
 	    int64 tl = (int64)OCI_LobGetLength(&conn->ocilib, l, xsink);
             if (!tl) {
                if (!*xsink)
@@ -865,18 +865,18 @@ AbstractQoreNode* objToQore(QoreOracleConnection* conn, OCI_Object* obj, Excepti
                xsink->raiseException("FETCH-NTY-ERROR", "Object of type %s.%s failed to allocate %d bytes for LOB attribute '%s'", get_typinf_schema(obj), get_typinf_name(obj), len, cname);
                return 0;
             }
-            
+
 	    if (!OCI_LobRead2(&conn->ocilib, l, (void*)b->getPtr(), &len, &len, xsink)) {
                if (!*xsink)
                   xsink->raiseException("FETCH-NTY-ERROR", "Object of type %s.%s failed to fetch %d bytes for LOB attribute '%s'", get_typinf_schema(obj), get_typinf_name(obj), len, cname);
                return 0;
             }
-            
+
             if (OCI_LobGetType(&conn->ocilib, l) == OCI_BLOB)
                rv->setKeyValue(cname, b.release(), xsink);
             else // clobs
                rv->setKeyValue(cname, new QoreStringNode((char*)b->giveBuffer(), len, len, conn->ds.getQoreEncoding()), xsink);
-	    
+
 	    break;
 	 }
 
@@ -929,7 +929,7 @@ AbstractQoreNode* objToQore(QoreOracleConnection* conn, OCI_Object* obj, Excepti
 	    return 0;
       } // switch
    }
-    
+
    return rv.release();
 }
 
@@ -945,7 +945,7 @@ OCI_Coll* collBindQore(QoreOracleConnection * d, const QoreHashNode * h, Excepti
 
    const QoreListNode * th = reinterpret_cast<const QoreListNode*>(h->getKeyValue("^values^"));
    const char * tname = reinterpret_cast<const QoreStringNode*>(h->getKeyValue("^oratype^"))->getBuffer();
-    
+
    OCI_TypeInfo * info = OCI_TypeInfoGet2(&d->ocilib, d->ocilib_cn, tname, OCI_TIF_TYPE, xsink);
    if (!info) {
       if (!*xsink)
@@ -967,17 +967,17 @@ OCI_Coll* collBindQore(QoreOracleConnection * d, const QoreHashNode * h, Excepti
          xsink->raiseException("BIND-NTY-ERROR", "failed to retrieve column information for column %d while attempting to bind collection of type '%s'", 1, tname);
       return 0;
    }
-        
+
 //     const char * cname = OCI_GetColumnName(col);
 //     printf("Binding attribute: %s\n", cname);
    OCI_Elem * e = OCI_ElemCreate2(&d->ocilib, info, xsink);
    if (!e) {
       if (!*xsink)
-         xsink->raiseException("BIND-NTY-ERROR", "failed to create element for binding collection '%s'", tname);      
+         xsink->raiseException("BIND-NTY-ERROR", "failed to create element for binding collection '%s'", tname);
       return 0;
    }
    ON_BLOCK_EXIT(OCI_ElemFree2, &d->ocilib, e, xsink);
-    
+
    for (size_t i = 0; i < th->size(); ++i) {
       const AbstractQoreNode * val = th->retrieve_entry(i);
 
@@ -1058,7 +1058,7 @@ OCI_Coll* collBindQore(QoreOracleConnection * d, const QoreHashNode * h, Excepti
                      if (!*xsink)
                         xsink->raiseException("BIND-NTY-ERROR", "NUMBER: unable to assign an arbitrary-precision number value to element for collection '%s'", tname);
                      return 0;
-                  }                      
+                  }
                   break;
                }
 #endif
@@ -1068,7 +1068,7 @@ OCI_Coll* collBindQore(QoreOracleConnection * d, const QoreHashNode * h, Excepti
                   break;
             }
             break;
-               
+
 	 case SQLT_INT:
 	    if (!OCI_ElemSetBigInt(&d->ocilib, e, val->getAsBigInt(), xsink)) {
                if (!*xsink)
@@ -1095,7 +1095,7 @@ OCI_Coll* collBindQore(QoreOracleConnection * d, const QoreHashNode * h, Excepti
 
 	 case SQLT_DAT:
 	 case SQLT_ODT:
-	 case SQLT_DATE: 
+	 case SQLT_DATE:
 #if OCI_VERSION_COMPILE >= OCI_9_0
 	 case SQLT_TIMESTAMP:
 	 case SQLT_TIMESTAMP_TZ:
@@ -1119,7 +1119,7 @@ OCI_Coll* collBindQore(QoreOracleConnection * d, const QoreHashNode * h, Excepti
                                             dn->getHour(), dn->getMinute(), dn->getSecond(),
                                             (dn->getMicrosecond() * 1000),
                                             0, xsink)) {
-                  if (!*xsink) 
+                  if (!*xsink)
                      xsink->raiseException("BIND-NTY-ERROR", "failed to create timestamp from date/time value for collection '%s'", tname);
                   return 0;
                }
@@ -1139,7 +1139,7 @@ OCI_Coll* collBindQore(QoreOracleConnection * d, const QoreHashNode * h, Excepti
 	       if (!OCI_DateSetDateTime(&d->ocilib, dt,
                                         dn->getYear(), dn->getMonth(), dn->getDay(),
                                         dn->getHour(), dn->getMinute(), dn->getSecond())) {
-                  if (!*xsink) 
+                  if (!*xsink)
                      xsink->raiseException("BIND-NTY-ERROR", "failed to create date/time value for collection '%s'", tname);
                   return 0;
                }
@@ -1160,12 +1160,12 @@ OCI_Coll* collBindQore(QoreOracleConnection * d, const QoreHashNode * h, Excepti
                   }
                   ON_BLOCK_EXIT(OCI_IntervalFree2, &d->ocilib, dt);
                   if (!OCI_IntervalSetYearMonth2(&d->ocilib, dt, dn->getYear(), dn->getMonth(), xsink)) {
-                     if (!*xsink) 
+                     if (!*xsink)
                         xsink->raiseException("BIND-NTY-ERROR", "failed to set interval year/month value for collection '%s'", tname);
                      return 0;
                   }
                   if (!OCI_ElemSetInterval2(&d->ocilib, e, dt, xsink)) {
-                     if (!*xsink) 
+                     if (!*xsink)
                         xsink->raiseException("BIND-NTY-ERROR", "failed to set interval value for collection '%s'", tname);
                      return 0;
                   }
@@ -1183,12 +1183,12 @@ OCI_Coll* collBindQore(QoreOracleConnection * d, const QoreHashNode * h, Excepti
                                                  dn->getDay(),
                                                  dn->getHour(), dn->getMinute(), dn->getSecond(),
                                                  (dn->getMicrosecond() * 1000), xsink)) {
-                     if (!*xsink) 
+                     if (!*xsink)
                         xsink->raiseException("BIND-NTY-ERROR", "failed to set interval day/second value for collection '%s'", tname);
                      return 0;
                   }
                   if (!OCI_ElemSetInterval2(&d->ocilib, e, dt, xsink)) {
-                     if (!*xsink) 
+                     if (!*xsink)
                         xsink->raiseException("BIND-NTY-ERROR", "failed to set interval value for collection '%s'", tname);
                      return 0;
                   }
@@ -1200,7 +1200,7 @@ OCI_Coll* collBindQore(QoreOracleConnection * d, const QoreHashNode * h, Excepti
 	    }
 	    break;
 	 }
-                
+
 
 //             case SQLT_RDD:
 //             case SQLT_RID:
@@ -1331,14 +1331,14 @@ OCI_Coll* collBindQore(QoreOracleConnection * d, const QoreHashNode * h, Excepti
 	    xsink->raiseException("BIND-COLLECTION-ERROR", "unknown datatype to bind as an attribute (unsupported): %s", col->typinf->name);
 	    return 0;
       } // switch
-      
+
       if (!OCI_CollAppend2(&d->ocilib, *obj, e, xsink)) {
          if (!*xsink)
             xsink->raiseException("BIND-NTY-ERROR", "failed to append element to collection '%s'", tname);
          return 0;
       }
    }
-    
+
    return obj.release();
 }
 
@@ -1365,13 +1365,10 @@ const char* get_typinf_name(OCI_Coll* obj) {
 
 AbstractQoreNode* collToQore(QoreOracleConnection* conn, OCI_Coll* obj, ExceptionSink *xsink) {
    ReferenceHolder<QoreListNode> rv(new QoreListNode, xsink);
-    
+
    int count = OCI_CollGetSize2(&conn->ocilib, obj, xsink);
-   if (!count) {
-      if (!*xsink)
-         xsink->raiseException("FETCH-NTY-ERROR", "Collection %s.%s failed to retrieve column count information", get_typinf_schema(obj), get_typinf_name(obj));
+   if (*xsink)
       return 0;
-   }
    OCI_Column *col = OCI_TypeInfoGetColumn2(&conn->ocilib, obj->typinf, 1, xsink);
    if (!col) {
       if (!*xsink)
@@ -1446,7 +1443,7 @@ AbstractQoreNode* collToQore(QoreOracleConnection* conn, OCI_Coll* obj, Exceptio
 
 	 case SQLT_DAT:
 	 case SQLT_ODT:
-	 case SQLT_DATE: 
+	 case SQLT_DATE:
 #if OCI_VERSION_COMPILE >= OCI_9_0
 	 case SQLT_TIMESTAMP:
 	 case SQLT_TIMESTAMP_TZ:
@@ -1457,7 +1454,7 @@ AbstractQoreNode* collToQore(QoreOracleConnection* conn, OCI_Coll* obj, Exceptio
 	 {
 	    // timestamps-like dates
 	    if (col->type == OCI_CDT_TIMESTAMP) {
-	       OCI_Timestamp* dt = OCI_ElemGetTimestamp2(&conn->ocilib, e); 
+	       OCI_Timestamp* dt = OCI_ElemGetTimestamp2(&conn->ocilib, e);
                if (!dt)
                   return xsink->raiseException("FETCH-NTY-ERROR", "Collection %s.%s failed to retrieve TIMESTAMP element for collection", get_typinf_schema(obj), get_typinf_name(obj));
 
@@ -1509,7 +1506,7 @@ AbstractQoreNode* collToQore(QoreOracleConnection* conn, OCI_Coll* obj, Exceptio
 	    }
 	    break;
 	 }
-                
+
 
 //             case SQLT_RDD:
 //             case SQLT_RID:
@@ -1536,7 +1533,7 @@ AbstractQoreNode* collToQore(QoreOracleConnection* conn, OCI_Coll* obj, Exceptio
             ON_BLOCK_EXIT(OCI_LobFree, &conn->ocilib, l, xsink);
 
             // The returned value is in bytes for BLOBS and characters for CLOBS/NCLOBs
-            
+
             int64 tl = (int64)OCI_LobGetLength(&conn->ocilib, l, xsink);
             if (!tl) {
                if (!*xsink)
@@ -1554,17 +1551,17 @@ AbstractQoreNode* collToQore(QoreOracleConnection* conn, OCI_Coll* obj, Exceptio
                xsink->raiseException("FETCH-NTY-ERROR", "Collection %s.%s failed to allocate %d bytes for collection", get_typinf_schema(obj), get_typinf_name(obj));
                return 0;
             }
-            
+
             if (!OCI_LobRead2(&conn->ocilib, l, (void*)b->getPtr(), &len, &len, xsink)) {
                if (!*xsink)
                   xsink->raiseException("FETCH-NTY-ERROR", "Collection %s.%s failed to fetch %d bytes for collection", get_typinf_schema(obj), get_typinf_name(obj));
                return 0;
             }
-            
+
             if (OCI_LobGetType(&conn->ocilib, l) == OCI_BLOB)
                rv->set_entry(rv->size(), b.release(), xsink);
             else
-               rv->set_entry(rv->size(), new QoreStringNode((char*)b->giveBuffer(), len, len, conn->ds.getQoreEncoding()), xsink);            
+               rv->set_entry(rv->size(), new QoreStringNode((char*)b->giveBuffer(), len, len, conn->ds.getQoreEncoding()), xsink);
 	    break;
          }
 
@@ -1616,7 +1613,7 @@ AbstractQoreNode* collToQore(QoreOracleConnection* conn, OCI_Coll* obj, Exceptio
 	    xsink->raiseException("FETCH-NTY-ERROR", "Collection %s.%s unknown datatype to fetch as an attribute: %d (define SQLT_...)", get_typinf_schema(obj), get_typinf_name(obj), col->ocode);
 	    return 0;
       } // switch
-        
+
    }
 
    assert(!*xsink);

--- a/test/nty/test_nty.q
+++ b/test/nty/test_nty.q
@@ -91,12 +91,12 @@ start();
 sub start() {
 
 	parse_command_line();
-   
+
 	#my string $connstr = "oracle:omqtest/omqtest@xbox";
     our Datasource $db($connstr);
     $db.open();
 
-    my int $id = 0; 
+    my int $id = 0;
     my int $prev_id = 0;
     my int $prev_success = 0;
 
@@ -116,7 +116,7 @@ sub start() {
     test_objects_out($id++);
     test_timestamp_in($id++);
     test_timestamp_out($id++);
-    my list $row_data = "Qore named types test - collections", sprintf("(%d/%d)", $success_count, $id);
+    my list $row_data = ("Qore named types test - collections", sprintf("(%d/%d)", $success_count, $id));
     print_row($row_data);
     $prev_id = $id;
     $prev_success = $success_count;
@@ -124,16 +124,16 @@ sub start() {
     test_exception2($id++);
     test_exception3($id++);
     test_exception4($id++);
-    $row_data = "Qore named types test - various errors checking", sprintf("(%d/%d)", $success_count-$prev_success, $id-$prev_id);
+    $row_data = ("Qore named types test - various errors checking", sprintf("(%d/%d)", $success_count-$prev_success, $id-$prev_id));
     print_row($row_data);
     $prev_id = $id;
     $prev_success = $success_count;
 
     test_object_insert($id++);
-    $row_data = "Qore named types test - objects", sprintf("(%d/%d)", $success_count-$prev_success, $id-$prev_id);
+    $row_data = ("Qore named types test - objects", sprintf("(%d/%d)", $success_count-$prev_success, $id-$prev_id));
     print_row($row_data);
 
-    $row_data = "TESTING COMPLETED", sprintf("(%d/%d)", $success_count, $id);
+    $row_data = ("TESTING COMPLETED", sprintf("(%d/%d)", $success_count, $id));
 
     print_row($row_data);
     print_char("-", COL_WIDTH+15);
@@ -158,10 +158,10 @@ sub usage() {
 
 
 sub parse_command_line() {
-    
+
 	my GetOpt $g(opts);
     $o = $g.parse(\$ARGV);
-	
+
     if (exists $o."_ERRORS_") {
         printf("%s\n", $o."_ERRORS_"[0]);
         exit(1);
@@ -177,14 +177,16 @@ sub parse_command_line() {
 	if(!exists $o.iters)
 	{
 		switch (gethostname()) {
-			case /^qube/: $connstr = "oracle:omquser2/omquser2@qube"; break;
-			case /^el6/:
-			case /^quark/: $connstr = "oracle:omquser/omquser@el6"; break;
-			case /^el5/:
-			case /^manatee/:
-			case /^xbox/: $connstr = "oracle:omquser/omquser@xbox"; break;
-			case /^ren/: $connstr = "oracle:omqtest/omqtest@xbox"; break;
-			default: $connstr = "oracle:omquser/omquser@xbox"; break;
+		    case /^quasar/: $connstr = "oracle:omquser/omquser@el7"; break;
+		    case /^quark/: $connstr = "oracle:omquser/omquser@el6"; break;
+		    case /^qube/: $connstr = "oracle:omquser2/omquser2@qube"; break;
+		    case /^el6/:
+		    case /^quark/: $connstr = "oracle:omquser/omquser@el6"; break;
+		    case /^el5/:
+		    case /^manatee/:
+		    case /^xbox/: $connstr = "oracle:omquser/omquser@xbox"; break;
+		    case /^ren/: $connstr = "oracle:omqtest/omqtest@xbox"; break;
+		    default: $connstr = "oracle:omquser/omquser@xbox"; break;
 		}
 	} else {
 		$connstr = $o.iters;
@@ -247,8 +249,8 @@ sub test_date_out(int id) {
 }
 
 sub test_object_collection_in(int id) {
-    my hash $obj = OBJ_HASH_MAIN + ( "A_OBJECT" : bindOracleObject("TEST_OBJECT_2", OBJ_HASH_SUPP),); 
-    my list $colo = bindOracleObject("TEST_OBJECT", $obj), bindOracleObject("TEST_OBJECT", $obj), bindOracleObject("TEST_OBJECT", $obj);
+    my hash $obj = OBJ_HASH_MAIN + ( "A_OBJECT" : bindOracleObject("TEST_OBJECT_2", OBJ_HASH_SUPP),);
+    my list $colo = (bindOracleObject("TEST_OBJECT", $obj), bindOracleObject("TEST_OBJECT", $obj), bindOracleObject("TEST_OBJECT", $obj));
     my $d = $db.exec("begin qore_test.do_coll_obj(%v, :retval); end;", bindOracleCollection("COL_TEST_obj", $colo));
     print_result($id, "collection IN object", cmp_result(NOTHING, $d.retval, COLL_OBJECT_IN), $colo, $d.retval);
     $db.rollback();
@@ -292,7 +294,7 @@ sub test_objects_out(int id) {
 }
 
 sub test_timestamp_in(int id) {
-    my list $colt = $c_date, $c_date, NULL, NOTHING, $c_date;
+    my list $colt = ($c_date, $c_date, NULL, NOTHING, $c_date);
     my $d = $db.exec("begin qore_test.do_coll_timestamp_tz(%v, :retval); end;", bindOracleCollection("COL_TEST_timestamp_tz", $colt));
     #printf("collection: %N\n", $d);
     print_result($id, "collection IN timestamp", cmp_result(NOTHING, $d.retval, COLL_TIMESTAMP_IN), TIMESTAMP_LST_IN, $d.retval);
@@ -337,7 +339,7 @@ sub test_exception2(int id) {
 
 sub test_exception3(int id) {
     try {
-        my list $col = STR_FOO, STR_BAR,NULL, NOTHING, STR_END;
+        my list $col = (STR_FOO, STR_BAR,NULL, NOTHING, STR_END);
         my $r = $db.exec("begin qore_test.do_coll(%v, :retval); end;",
                 $col, # missing bindOracleObject
                 Type::String);
@@ -365,7 +367,7 @@ sub test_object_insert(int id) {
 
 	on_success $db.commit();
 	on_error $db.rollback();
-	
+
 	try {
 	    # ensure we can insert with lower-case object keys
 	    my hash $h;
@@ -376,7 +378,7 @@ sub test_object_insert(int id) {
 				bindOracleObject("TEST_tab_OBJECT", $h),
 				bindOracleCollection("TEST_tab_coll", (NUM_INT, NUM_INT, NULL, NOTHING, NUM_INT,))
 				);
-	    if($rins == 1) 
+	    if($rins == 1)
 		print_result($id, "object direct insert", Qore::True, "object insert to db succesfull", $rins);
 	    else
 		print_result($id, "object direct insert", Qore::False, "object insert to db unsuccesfull", $rins);

--- a/test/nty/test_nty_collection.q
+++ b/test/nty/test_nty_collection.q
@@ -5,6 +5,7 @@ printf("\nQore named types test - collections\n\n");
 
 my string $connstr;
 switch (gethostname()) {
+    case /^quasar/: $connstr = "oracle:omquser/omquser@el7"; break;
     case /^qube/: $connstr = "oracle:omquser2/omquser2@qube"; break;
     case /^el6/:
     case /^quark/: $connstr = "oracle:omquser/omquser@el6"; break;
@@ -19,7 +20,7 @@ my Datasource $db($connstr);
 $db.open();
 
 printf("\nCOLLECTION IN varchar2\n");
-my list $col = 'foo', 'bar',NULL, NOTHING, "the end";
+my list $col = ('foo', 'bar',NULL, NOTHING, "the end");
 my hash $c = $db.exec("begin qore_test.do_coll(%v, :retval); end;",
                  bindOracleCollection("COL_TEST", $col));
 printf("collection: %N\n", $c);
@@ -32,7 +33,7 @@ $db.rollback();
 
 
 printf("\nCOLLECTION IN number\n");
-$col = 2, 213,NULL, NOTHING, "23932", 500n, 3.1415927;
+$col = (2, 213,NULL, NOTHING, "23932", 500n, 3.1415927);
 $c = $db.exec("begin qore_test.do_coll_num(%v, :retval); end;",
                  bindOracleCollection("COL_TEST_NUM", $col));
 printf("collection: %N\n", $c);
@@ -45,7 +46,7 @@ $db.rollback();
 
 
 printf("\nCOLLECTION IN clob\n");
-$col = 'foo', 'bar',NULL, NOTHING, "the end";
+$col = ('foo', 'bar',NULL, NOTHING, "the end");
 $c = $db.exec("begin qore_test.do_coll_clob(%v, :retval); end;",
                  bindOracleCollection("COL_TEST_CLOB", $col));
 printf("collection: %N\n", $c);
@@ -58,7 +59,7 @@ $db.rollback();
 
 
 printf("\nCOLLECTION IN date\n");
-$cold = now(), now_ms(), NULL, NOTHING, now()+10;
+$cold = (now(), now_ms(), NULL, NOTHING, now()+10);
 $d = $db.exec("begin qore_test.do_coll_date(%v, :retval); end;",
                  bindOracleCollection("COL_TEST_date", $cold));
 printf("collection: %N\n", $d);
@@ -81,9 +82,10 @@ my hash $obj = ("A_TEXT": "1",
                 "A_TSTAMP_TZ" : now_ms(),
                 "A_OBJECT" : bindOracleObject("TEST_OBJECT_2", ("TEXT2" : "foobar", "NUMBER2" : 666))
                 );
-my list $colo = bindOracleObject("TEST_OBJECT", $obj),
-                bindOracleObject("TEST_OBJECT", $obj),
-                bindOracleObject("TEST_OBJECT", $obj);
+my list $colo = (bindOracleObject("TEST_OBJECT", $obj),
+		 bindOracleObject("TEST_OBJECT", $obj),
+		 bindOracleObject("TEST_OBJECT", $obj),
+		 );
 $d = $db.exec("begin qore_test.do_coll_obj(%v, :retval); end;",
                  bindOracleCollection("COL_TEST_obj", $colo));
 printf("collection: %N\n", $d);
@@ -128,7 +130,7 @@ $db.rollback();
 
 
 printf("\nCOLLECTION IN timestamp\n");
-my list $colt = now(), now_ms(), NULL, NOTHING, now()+10;
+my list $colt = (now(), now_ms(), NULL, NOTHING, now()+10);
 my $d = $db.exec("begin qore_test.do_coll_timestamp_tz(%v, :retval); end;",
                  bindOracleCollection("COL_TEST_timestamp_tz", $colt));
 printf("collection: %N\n", $d);

--- a/test/nty/test_nty_object.q
+++ b/test/nty/test_nty_object.q
@@ -5,6 +5,7 @@ printf("\nQore named types test - objects\n\n");
 
 my string $connstr;
 switch (gethostname()) {
+    case /^quasar/: $connstr = "oracle:omquser/omquser@el7"; break;
     case /^qube/: $connstr = "oracle:omquser2/omquser2@qube"; break;
     case /^el6/:
     case /^quark/: $connstr = "oracle:omquser/omquser@el6"; break;


### PR DESCRIPTION
… a table for example) could not be used

with the fix:

```
rv: hash: (2 members)
  x_status : list: (1 element)
    [0]=hash: (3 members)
      STATUS_CODE : 1
      ERROR_CODE : "0"
      ERROR_DESCRIPTION : "ORA-0000: normal, successful completion"
  x_param_out : <EMPTY LIST>
```

(which is the expected output)
