### PR TITLE
refs qorelanguage/qore@537 ensure that cache NTY info is cleared befo…

### DIFF
--- a/src/QoreOracleConnection.cpp
+++ b/src/QoreOracleConnection.cpp
@@ -189,8 +189,6 @@ QoreOracleConnection::~QoreOracleConnection() {
       logoff();
 
    if (ocilib_cn) {
-      clearCache();
-
       OCI_FREE(ocilib_cn->fmt_num);
 
       if (ocilib_cn->trace)

--- a/src/QoreOracleConnection.h
+++ b/src/QoreOracleConnection.h
@@ -202,9 +202,11 @@ public:
    // logoff but do not process error return values
    DLLLOCAL int logoff() {
       assert(svchp);
-//      int rc = OCILogoff(svchp, errhp);
-//      OCIHandleFree(svchp, OCI_HTYPE_SVCCTX);
-//      svchp = 0;
+
+      // free all cached typeinfo objects
+      if (ocilib_cn)
+         clearCache();
+
       int rc = OCISessionEnd(svchp, errhp, usrhp, 0);
       OCIServerDetach(srvhp, errhp, OCI_DEFAULT);
       return rc;

--- a/src/QoreOracleStatement.cpp
+++ b/src/QoreOracleStatement.cpp
@@ -88,9 +88,6 @@ int QoreOracleStatement::execute(ExceptionSink* xsink, const char* who) {
 	 // try to reconnect
 	 conn.logoff();
 
-         // free all cached typeinfo objects
-         conn.clearCache();
-
 	 //printd(0, "QoreOracleStatement::execute() about to execute OCILogon() for reconnect\n");
 	 if (conn.logon(xsink)) {
             //printd(5, "QoreOracleStatement::execute() conn: %p reconnect failed, marking connection as closed\n", conn);


### PR DESCRIPTION
…re the connection is closed and not after
