### PR TITLE
refs qorelanguage/qore#589 fixed a bug where SQLStatement::describe()…

### DIFF
--- a/RELEASE-NOTES
+++ b/RELEASE-NOTES
@@ -45,6 +45,8 @@ version 3.2
   example) could not be used
 * fixed a bug where cached NTY information was reused with stale pointers
   when connections were reestablished
+* fixed a bug where SQLStatement::describe() was failing even though result
+  set information was available
 
 
 ***********

--- a/docs/mainpage.doxygen.tmpl
+++ b/docs/mainpage.doxygen.tmpl
@@ -495,6 +495,7 @@ kpcest_err_handler: Max errors exceeded..Closing connection
     - fixed a bug where number values were being returned with decimal points truncated in locales where the decimal position is not marked with a dot
     - fixed a bug where collections with no columns (but based on a table for example) could not be used (<a href="https://github.com/qorelanguage/qore/issues/455">issue 455</a>)
     - fixed a bug where cached NTY information was reused with stale pointers when connections were reestablished (<a href="https://github.com/qorelanguage/qore/issues/537">issue 537</a>)
+    - fixed a bug where SQLStatement::describe() was failing even though result set information was available
 
     @subsection oracle31 oracle Driver Version 3.1
 

--- a/src/QoreOracleStatement.cpp
+++ b/src/QoreOracleStatement.cpp
@@ -355,11 +355,6 @@ QoreHashNode* QoreOracleStatement::fetchColumns(OraResultSet& resultset, int row
 
 #ifdef _QORE_HAS_DBI_DESCRIBE
 QoreHashNode* QoreOracleStatement::describe(OraResultSet& resultset, ExceptionSink* xsink) {
-   if (!fetch_done) {
-      xsink->raiseException("ORACLE-DESCRIBE-ERROR", "call SQLStatement::next() before calling SQLStatement::describe()");
-      return 0;
-   }
-
    // set up hash for row
    ReferenceHolder<QoreHashNode> h(new QoreHashNode, xsink);
    QoreString namestr("name");


### PR DESCRIPTION
… was failing even though result set information was available
