### PR TITLE
refs qorelanguage/qore#2773 added support for the STMT EXEC DESCRIBE …

### DIFF
--- a/docs/mainpage.doxygen.tmpl
+++ b/docs/mainpage.doxygen.tmpl
@@ -527,6 +527,9 @@ kpcest_err_handler: Max errors exceeded..Closing connection
     @section ora_releasenotes Release Notes
 
     @subsection oracle33 oracle Driver Version 3.3
+    - added support for the <tt>STMT EXEC DESCRIBE</tt> DBI method for efficient describing of SQL statements without
+      executing the statement itself and therefore avoiding a large performance penalty for this operation
+      (<a href="https://github.com/qorelanguage/qore/issues/2773">issue 2773</a>)
     - added support for the \c RESULTSET placeholder specification and the \c DBI_CAP_HAS_RESULTSET_OUTPUT driver capability
       that allow result set output variables to be returned as @ref Qore::SQL::SQLStatement "SQLStatement" objects
       (<a href="https://github.com/qorelanguage/qore/issues/1300">issue 1300</a>)

--- a/src/QorePreparedStatement.cpp
+++ b/src/QorePreparedStatement.cpp
@@ -1908,14 +1908,14 @@ AbstractQoreNode* OraBindNode::getValue(bool horizontal, ExceptionSink* xsink) {
    return OraColumnValue::getValue(xsink, horizontal, true);
 }
 
-int QorePreparedStatement::execute(ExceptionSink* xsink, const char* who) {
+int QorePreparedStatement::execute(ExceptionSink* xsink, const char* who, int oci_flags) {
    assert(conn.svchp);
    ub4 iters;
    if (is_select)
       iters = 0;
    else
       iters = !array_size ? 1 : array_size;
-   int status = OCIStmtExecute(conn.svchp, stmthp, conn.errhp, iters, 0, 0, 0, OCI_DEFAULT);
+   int status = OCIStmtExecute(conn.svchp, stmthp, conn.errhp, iters, 0, 0, 0, OCI_DEFAULT | oci_flags);
 
    //printd(5, "QoreOracleStatement::execute() stmthp: %p status: %d (OCI_ERROR: %d)\n", stmthp, status, OCI_ERROR);
    if (status == OCI_ERROR) {
@@ -1982,7 +1982,7 @@ int QorePreparedStatement::execute(ExceptionSink* xsink, const char* who) {
          assert(!*xsink);
 
          //printd(5, "QoreOracleStatement::execute() returned from OCILogon() status: %d\n", status);
-         status = OCIStmtExecute(conn.svchp, stmthp, conn.errhp, iters, 0, 0, 0, OCI_DEFAULT);
+         status = OCIStmtExecute(conn.svchp, stmthp, conn.errhp, iters, 0, 0, 0, OCI_DEFAULT | oci_flags);
          if (status && conn.checkerr(status, who, xsink))
             return -1;
       }
@@ -2001,6 +2001,11 @@ int QorePreparedStatement::execute(ExceptionSink* xsink, const char* who) {
 
 int QorePreparedStatement::exec(ExceptionSink* xsink) {
    return execute(xsink, "QorePreparedStatement::exec()");
+}
+
+int QorePreparedStatement::execDescribe(ExceptionSink* xsink) {
+    //printd(5, "QorePreparedStatement::execDescribe() this: %p\n", this);
+    return execute(xsink, "QorePreparedStatement::execDescribe()", OCI_DESCRIBE_ONLY);
 }
 
 void QorePreparedStatement::clear(ExceptionSink* xsink) {

--- a/src/QorePreparedStatement.h
+++ b/src/QorePreparedStatement.h
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2006 - 2017 Qore Technologies, s.r.o.
+  Copyright (C) 2006 - 2018 Qore Technologies, s.r.o.
 
   This library is free software; you can redistribute it and/or
   modify it under the terms of the GNU Lesser General Public
@@ -337,13 +337,15 @@ public:
       return c;
    }
 
-   DLLLOCAL int execute(ExceptionSink* xsink, const char* who);
+   DLLLOCAL int execute(ExceptionSink* xsink, const char* who, int oci_flags = 0);
 
    DLLLOCAL int bind(const QoreListNode* args, ExceptionSink* xsink);
    DLLLOCAL int bindPlaceholders(const QoreListNode* args, ExceptionSink* xsink);
    DLLLOCAL int bindValues(const QoreListNode* args, ExceptionSink* xsink);
 
    DLLLOCAL int exec(ExceptionSink* xsink);
+
+   DLLLOCAL int execDescribe(ExceptionSink* xsink);
 
    DLLLOCAL int define(ExceptionSink* xsink);
 

--- a/src/oracle.cpp
+++ b/src/oracle.cpp
@@ -6,7 +6,7 @@
 
   Qore Programming Language
 
-  Copyright (C) 2003 - 2017 Qore Technologies, s.r.o.
+  Copyright (C) 2003 - 2018 Qore Technologies, s.r.o.
 
   This library is free software; you can redistribute it and/or
   modify it under the terms of the GNU Lesser General Public
@@ -243,6 +243,13 @@ static int oracle_stmt_exec(SQLStatement* stmt, ExceptionSink* xsink) {
    return bg->exec(xsink);
 }
 
+static int oracle_stmt_exec_describe(SQLStatement* stmt, ExceptionSink* xsink) {
+   QorePreparedStatement* bg = (QorePreparedStatement*)stmt->getPrivateData();
+   assert(bg);
+
+   return bg->execDescribe(xsink);
+}
+
 static int oracle_stmt_define(SQLStatement* stmt, ExceptionSink* xsink) {
    QorePreparedStatement* bg = (QorePreparedStatement*)stmt->getPrivateData();
    assert(bg);
@@ -368,6 +375,7 @@ QoreStringNode* oracle_module_init() {
    methods.add(QDBI_METHOD_STMT_BIND_PLACEHOLDERS, oracle_stmt_bind_placeholders);
    methods.add(QDBI_METHOD_STMT_BIND_VALUES, oracle_stmt_bind_values);
    methods.add(QDBI_METHOD_STMT_EXEC, oracle_stmt_exec);
+   methods.add(QDBI_METHOD_STMT_EXEC_DESCRIBE, oracle_stmt_exec_describe);
    methods.add(QDBI_METHOD_STMT_DEFINE, oracle_stmt_define);
    methods.add(QDBI_METHOD_STMT_FETCH_ROW, oracle_stmt_fetch_row);
    methods.add(QDBI_METHOD_STMT_FETCH_ROWS, oracle_stmt_fetch_rows);


### PR DESCRIPTION
…DBI method for efficient describing of SQL statements without executing the statement itself and therefore avoiding a large performance penalty for this operation