### PR TITLE
refs qoretechnologies/qore#5093 fixed memory management bugs and code quality issues

### DIFF
--- a/src/OraColumnValue.cpp
+++ b/src/OraColumnValue.cpp
@@ -91,12 +91,12 @@ void OraColumnValue::del(ExceptionSink *xsink) {
 
         case SQLT_INTERVAL_YM:
             if (buf.oi)
-                OCIDescriptorFree(buf.odt, OCI_DTYPE_INTERVAL_YM);
+                OCIDescriptorFree(buf.oi, OCI_DTYPE_INTERVAL_YM);
             break;
 
         case SQLT_INTERVAL_DS:
             if (buf.oi)
-                OCIDescriptorFree(buf.odt, OCI_DTYPE_INTERVAL_DS);
+                OCIDescriptorFree(buf.oi, OCI_DTYPE_INTERVAL_DS);
             break;
 
         case SQLT_BIN:

--- a/src/QC_AQQueue.qpp
+++ b/src/QC_AQQueue.qpp
@@ -148,13 +148,13 @@ public:
             ExceptionSink xsink;
             // remove object from list if reconnection fails
             if (o->reconnectSubscription(&xsink)) {
-               objects.erase(it);
+               it = objects.erase(it);
                if (objects.empty())
                   quit = true;
                aqCallbackThreadManager.dec();
+               o->qoreObject()->evalMethod("onSubscriptionLost", 0, &xsink);
+               continue;
             }
-
-            o->qoreObject()->evalMethod("onSubscriptionLost", 0, &xsink);
          }
 
          ++it;
@@ -427,7 +427,7 @@ bool AQQueuePriv::post(AQMessagePriv *message, ExceptionSink *xsink) {
 
     if (!OCI_MsgSetObject(&m_conn->ocilib, m, o, xsink)) {
        if (!*xsink)
-          xsink->raiseException("AQQUEUE-ERROR", "cannot se message object");
+          xsink->raiseException("AQQUEUE-ERROR", "cannot set message object");
        return false;
     }
 


### PR DESCRIPTION
## Summary

- Fixed wrong descriptor being freed for INTERVAL types in `OraColumnValue.cpp` (was freeing `buf.odt` instead of `buf.oi`)
- Fixed iterator invalidation in `AQSubscriptionManager::ping()` (iterator was incremented after erase without reassignment)
- Fixed typo in error message ("cannot se" → "cannot set")
- Removed redundant `onSubscriptionLost` call on successful reconnect (per Copilot review)

Fixes qoretechnologies/qore#5093

## Test plan

- [x] All existing tests pass (`oracle.qtest`, `db.qtest`, `sql-stmt.qtest`, `nty.qtest`)
- [x] Tests pass under valgrind (no memory issues from module code)
- [x] Copilot review feedback addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)